### PR TITLE
chore: bump version to 3.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.8.1] - 2025-11-28
+
 ### Added
 - **CM2000 Software Version** - Parse firmware version from index.htm InitTagValue() (Issue #38)
 - **CM2000 Restart Support** - Remote modem restart via RouterStatus.htm buttonSelect=2 (Issue #38)

--- a/custom_components/cable_modem_monitor/const.py
+++ b/custom_components/cable_modem_monitor/const.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-VERSION = "3.8.0"
+VERSION = "3.8.1"
 
 DOMAIN = "cable_modem_monitor"
 CONF_HOST = "host"

--- a/custom_components/cable_modem_monitor/manifest.json
+++ b/custom_components/cable_modem_monitor/manifest.json
@@ -12,6 +12,6 @@
     "beautifulsoup4==4.12.2",
     "defusedxml==0.7.1"
   ],
-  "version": "3.8.0",
+  "version": "3.8.1",
   "integration_type": "device"
 }

--- a/tests/components/test_version_and_startup.py
+++ b/tests/components/test_version_and_startup.py
@@ -97,7 +97,7 @@ class TestVersionLogging:
 
     def test_current_version(self):
         """Test that version is the correct current version."""
-        assert VERSION == "3.8.0"
+        assert VERSION == "3.8.1"
 
 
 class TestParserSelectionOptimization:


### PR DESCRIPTION
## Summary
Bump version to 3.8.1 for release.

## Test Plan
- [x] Version updated in manifest.json
- [x] Version updated in const.py

🤖 Generated with [Claude Code](https://claude.com/claude-code)