### PR TITLE
chore: release v3.8.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.8.5] - 2025-11-30
+
+### Fixed
+- **SB8200 Uptime Sensor** - Fix uptime showing "Unknown" by using correct `system_uptime` key (Issue #42)
+
 ## [3.8.4] - 2025-11-30
 
 ## [3.8.3] - 2025-11-29

--- a/custom_components/cable_modem_monitor/const.py
+++ b/custom_components/cable_modem_monitor/const.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-VERSION = "3.8.4"
+VERSION = "3.8.5"
 
 DOMAIN = "cable_modem_monitor"
 CONF_HOST = "host"

--- a/custom_components/cable_modem_monitor/manifest.json
+++ b/custom_components/cable_modem_monitor/manifest.json
@@ -12,6 +12,6 @@
     "beautifulsoup4==4.12.2",
     "defusedxml==0.7.1"
   ],
-  "version": "3.8.4",
+  "version": "3.8.5",
   "integration_type": "device"
 }

--- a/custom_components/cable_modem_monitor/parsers/arris/sb8200.py
+++ b/custom_components/cable_modem_monitor/parsers/arris/sb8200.py
@@ -286,10 +286,9 @@ class ArrisSB8200Parser(ModemParser):
                     value = cells[1].get_text(strip=True)
 
                     if "Up Time" in label:
-                        uptime_seconds = self._parse_uptime(value)
-                        if uptime_seconds is not None:
-                            info["uptime"] = uptime_seconds
-                            _LOGGER.debug("Parsed SB8200 uptime: %s seconds", uptime_seconds)
+                        # Store as string for display (matches other parsers)
+                        info["system_uptime"] = value
+                        _LOGGER.debug("Parsed SB8200 uptime: %s", value)
 
                     elif "Hardware Version" in label:
                         info["hardware_version"] = value

--- a/tests/components/test_version_and_startup.py
+++ b/tests/components/test_version_and_startup.py
@@ -97,7 +97,7 @@ class TestVersionLogging:
 
     def test_current_version(self):
         """Test that version is the correct current version."""
-        assert VERSION == "3.8.4"
+        assert VERSION == "3.8.5"
 
 
 class TestParserSelectionOptimization:

--- a/tests/parsers/arris/test_sb8200.py
+++ b/tests/parsers/arris/test_sb8200.py
@@ -244,9 +244,9 @@ class TestSB8200ProductInfoParsing:
         soup = BeautifulSoup(sb8200_product_info_html, "html.parser")
         info = parser._parse_product_info(soup)
 
-        assert "uptime" in info
-        # "8 days 01h:16m:13s.00" = 8*86400 + 1*3600 + 16*60 + 13 = 695773 seconds
-        assert info["uptime"] == 695773
+        assert "system_uptime" in info
+        # Stored as raw string for display (matches other parsers)
+        assert info["system_uptime"] == "8 days 01h:16m:13s.00"
 
     def test_parse_hardware_version(self, sb8200_product_info_html):
         """Test hardware version parsing."""


### PR DESCRIPTION
## Summary
- Fix SB8200 uptime sensor showing "Unknown" by using correct `system_uptime` key (Issue #42)
- Bump version to 3.8.5

## Test Plan
- [x] All 692 tests passing
- [x] Pre-commit hooks pass

Related to #42

Co-Authored with Claude <noreply@anthropic.com>