### PR TITLE
Release v3.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.10.1] - 2025-12-17
+
+### Highlights
+
+🏪 **HACS Default Repository Submission** - Preparing for inclusion in the HACS default repository list
+
+### Added
+- **Hassfest Validation** - Added hassfest CI workflow required for HACS default submission
+- **AI Skills** - Added modem-request-triage and issue-to-fixture AI skills for development workflow
+
+### Fixed
+- **Manifest Key Order** - Sorted manifest.json keys per Home Assistant requirements (domain, name, then alphabetical)
+- **Test Warnings** - Resolved implicit string concatenation warnings in test_s33.py
+
+### Changed
+- **Scripts Cleanup** - Removed 6 superseded maintenance scripts
+
 ## [3.10.0] - 2025-12-16
 
 ### Highlights

--- a/custom_components/cable_modem_monitor/const.py
+++ b/custom_components/cable_modem_monitor/const.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-VERSION = "3.10.0"
+VERSION = "3.10.1"
 
 DOMAIN = "cable_modem_monitor"
 CONF_HOST = "host"

--- a/custom_components/cable_modem_monitor/manifest.json
+++ b/custom_components/cable_modem_monitor/manifest.json
@@ -13,5 +13,5 @@
     "beautifulsoup4==4.12.2",
     "defusedxml==0.7.1"
   ],
-  "version": "3.10.0"
+  "version": "3.10.1"
 }

--- a/tests/components/test_version_and_startup.py
+++ b/tests/components/test_version_and_startup.py
@@ -97,7 +97,7 @@ class TestVersionLogging:
 
     def test_current_version(self):
         """Test that version is the correct current version."""
-        assert VERSION == "3.10.0"
+        assert VERSION == "3.10.1"
 
 
 class TestParserSelectionOptimization:


### PR DESCRIPTION
## Summary
🏪 **HACS Default Repository Submission** preparation release

### Added
- Hassfest validation workflow for HACS default submission
- AI skills for modem parser development workflow

### Fixed
- Manifest key order per Home Assistant requirements
- Test warnings in test_s33.py

### Changed
- Removed 6 superseded maintenance scripts

## Test plan
- [x] All 875 tests passing locally
- [ ] CI passes on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)