### PR TITLE
fix(ci): release workflow uses pytest.ini testpaths

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,7 +76,8 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r tests/requirements.txt
-          pytest tests/ -v
+          # Use pytest without path argument to respect pytest.ini testpaths (tests + modems)
+          pytest
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
## Summary
The release workflow was running `pytest tests/` which excluded the `modems/` tests, causing coverage to drop below 60% (56% vs 60% required).

## Fix
Changed to just `pytest` which respects pytest.ini's `testpaths` setting that includes both `tests` and `modems` directories.

## Impact
This fixes the v3.12.0 release workflow failure. After merging, we need to:
1. Delete the v3.12.0 tag
2. Recreate it pointing to the new HEAD
3. The release workflow will re-run with correct coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)