### PR TITLE
fix: prevent redundant auth for basic_http modems (v3.13.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [3.13.1] - 2026-02-27
 
+### Fixed
+
+- **CM1200 zero channel data regression** - Fixed redundant authentication call that caused basic_http modems (CM1200, C7000v2, CM600, C3700, TC4400) to make an extra HTTP request per poll cycle. The `_pre_authenticate()` gate condition incorrectly used HTML presence as a proxy for "auth was performed," but basic_http auth is stateless and never returns HTML. This caused connection resets on modems that rate-limit rapid HTTPS requests. (#121)
+
 ## [3.13.0] - 2026-02-24
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.13.1] - 2026-02-27
+
 ## [3.13.0] - 2026-02-24
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -190,6 +190,8 @@ git push --force-with-lease
 ## PR and Issue Rules
 
 **NEVER use "Closes #X", "Fixes #X", or similar auto-close keywords.**
+- This applies to **both PR bodies AND commit messages**
+- GitHub scans all commit messages in a merge — a `Fixes #X` buried in any commit on the branch will auto-close the issue when merged to main
 - Users should close their own tickets after confirming fixes work
 - Use "Related to #X" or "Addresses #X" instead
 

--- a/custom_components/cable_modem_monitor/const.py
+++ b/custom_components/cable_modem_monitor/const.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 # IMPORTANT: Do not edit VERSION manually!
 # Use: python scripts/release.py <version>
 # The script updates this file, manifest.json, and test_version_and_startup.py
-VERSION = "3.13.0"
+VERSION = "3.13.1"
 
 DOMAIN = "cable_modem_monitor"
 CONF_HOST = "host"

--- a/custom_components/cable_modem_monitor/manifest.json
+++ b/custom_components/cable_modem_monitor/manifest.json
@@ -17,5 +17,5 @@
     "defusedxml==0.7.1",
     "har-capture>=0.3.3,<0.4.0"
   ],
-  "version": "3.13.0"
+  "version": "3.13.1"
 }

--- a/tests/components/test_data_orchestrator.py
+++ b/tests/components/test_data_orchestrator.py
@@ -1895,8 +1895,8 @@ class TestPreAuthenticate:
 
         result = orchestrator._pre_authenticate()
 
-        # Should return success without calling _login
-        assert result == (True, None)
+        # Should return success without calling _login, auth_performed=False
+        assert result == (True, None, False)
         mock_login.assert_not_called()
 
     def test_pre_authenticates_for_hnap_session(self, mocker):
@@ -1918,9 +1918,9 @@ class TestPreAuthenticate:
 
         result = orchestrator._pre_authenticate()
 
-        # Should call _login for HNAP
+        # Should call _login for HNAP, auth_performed=True
         mock_login.assert_called_once()
-        assert result == (True, "<html>auth</html>")
+        assert result == (True, "<html>auth</html>", True)
 
     def test_pre_authenticates_for_form_plain(self, mocker):
         """Test that pre-auth IS performed for form_plain strategy."""
@@ -1937,7 +1937,7 @@ class TestPreAuthenticate:
         result = orchestrator._pre_authenticate()
 
         mock_login.assert_called_once()
-        assert result == (True, None)
+        assert result == (True, None, True)
 
     def test_pre_authenticates_for_form_ajax(self, mocker):
         """Test that pre-auth IS performed for form_ajax strategy."""
@@ -1969,7 +1969,7 @@ class TestPreAuthenticate:
 
         result = orchestrator._pre_authenticate()
 
-        assert result == (True, None)
+        assert result == (True, None, False)
         mock_login.assert_not_called()
 
     def test_skips_pre_auth_when_no_strategy(self, mocker):
@@ -1986,7 +1986,7 @@ class TestPreAuthenticate:
 
         result = orchestrator._pre_authenticate()
 
-        assert result == (True, None)
+        assert result == (True, None, False)
         mock_login.assert_not_called()
 
     def test_url_token_uses_reactive_auth_flow(self, mocker):

--- a/tests/components/test_version_and_startup.py
+++ b/tests/components/test_version_and_startup.py
@@ -113,7 +113,7 @@ class TestVersionLogging:
         Use: python scripts/release.py <version>
         The script updates const.py, manifest.json, and this file.
         """
-        assert VERSION == "3.13.0"
+        assert VERSION == "3.13.1"
 
 
 class TestProtocolOptimizationIntegration:


### PR DESCRIPTION
## Summary

- **Fixed redundant authentication** for `basic_http` modems (CM1200, C7000v2, CM600, C3700, TC4400). The `_pre_authenticate()` gate condition used HTML presence as a proxy for "was auth performed?" but basic_http is stateless and never returns HTML — causing a second `_login()` call and extra HTTP request every poll cycle. Modems that rate-limit rapid HTTPS requests (e.g., CM1200) returned zero channel data as a result.
- Changed `_pre_authenticate()` to return an explicit `auth_performed` flag instead of inferring from HTML.

## Test plan

- [x] All 2545 tests pass, ruff/black/mypy clean
- [x] Verified fix reduces basic_http polls from 4 HTTP requests to 3 (1 login + 2 data pages)
- [x] Verified no behavior change for other auth strategies (form_plain, hnap_json, url_token_session, no_auth)
- [ ] Dogfood on local HA (if warranted)
- [ ] User (@DeFlanko) confirms CM1200 channel data restored

Related to #121

🤖 Generated with [Claude Code](https://claude.com/claude-code)