### PR TITLE
fix(ci): drop duplicate test step from release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,11 +20,6 @@ jobs:
           fetch-depth: 0
           lfs: true
 
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: "3.12"
-
       - name: Extract version from tag
         id: version
         run: |
@@ -82,19 +77,14 @@ jobs:
           # Save to file to preserve formatting
           echo "$CHANGELOG" > /tmp/changelog.txt
 
-      - name: Install test dependencies
-        run: |
-          pip install -r tests/requirements.txt
-
-      - name: Run tests
-        run: |
-          pytest -v --tb=short
-
       - name: Package integration for HACS
         run: |
           cd custom_components/cable_modem_monitor
           # Exclude docs/ (dev specs, not needed at runtime) and
-          # Python bytecode cache (created by the pytest step above).
+          # any bytecode cache. Tests run in tests.yml on every
+          # push to main and feature/*; release.yml does not
+          # re-run them — by the time we tag, tests have already
+          # passed on the same commit.
           zip -r ../../cable_modem_monitor.zip . -x 'docs/*' '*__pycache__*'
 
       - name: Create GitHub Release


### PR DESCRIPTION
## Summary

- `release.yml` was running pytest with an incomplete install (missing `pip install -e packages/...`). The bug was hidden because alpha tags had been skipping the workflow entirely; `v3.14.0-beta.1` was the first time the workflow actually ran post-carve-out and it failed at the test step.
- Tests are already covered by `tests.yml` on every push to `main` and `feature/*`. By the time a tag is created, tests have passed on the same commit. Re-running them in `release.yml` was duplicate work and a drift surface (tests.yml's install differed from release.yml's).
- Removed: \`Set up Python\`, \`Install test dependencies\`, \`Run tests\` from release.yml. Net change: 14 deletions, 4 additions (comment refresh in the zip step explaining the new logic).

## Test plan

- [ ] All 8 required status checks pass on this PR (especially \`Validate Commit Messages\`, which only fires on PR — first chance we've had to validate it works)
- [ ] After merge, the next tag push will exercise the simplified \`release.yml\` end-to-end on real CI
- [ ] No functional change to what the workflow ships (zip contents, release notes, prerelease flag) — only the test-running scaffolding is removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)