### PR TITLE
fix: recover expired HNAP sessions within the same poll

### DIFF
--- a/packages/cable_modem_monitor_core/docs/ORCHESTRATION_USE_CASES.md
+++ b/packages/cable_modem_monitor_core/docs/ORCHESTRATION_USE_CASES.md
@@ -347,36 +347,46 @@ Session may be stale, or strategy doesn't grant data access.
 | 2 | Collector: auth succeeds (or session reused) | | |
 | 3 | Resource Loader: GET /status.html → HTTP 401 | | |
 | 4 | Collector returns `ModemResult(signal=LOAD_AUTH)` | | |
-| 5 | Orchestrator: streak++ | | |
-| 6 | Orchestrator: collector.clear_session() | session cleared | |
-| 7 | Return `ModemSnapshot(AUTH_FAILED)` | | |
+| 5 | Orchestrator: collector.clear_session() | session cleared | |
+| 6 | Orchestrator: retry collection once in same poll | | |
+| 7 | Retry still fails | | |
+| 8 | Orchestrator: streak++ | | |
+| 9 | Return `ModemSnapshot(AUTH_FAILED)` | | |
 
 **Assertions:**
 
-- Session is cleared so next poll starts with fresh login
+- Session is cleared before the same-poll retry
+- Orchestrator retries LOAD_AUTH once in the same poll
 - Auth failure streak is incremented (LOAD_AUTH is auth-related)
-- If persistent, will escalate to circuit breaker (same as wrong credentials)
+- If the retry also fails, the failure remains auth-related and can
+  still escalate to the circuit breaker
 - INFO log: "LOAD_AUTH — clearing session, reporting auth_failed..."
 
 ---
 
 ### UC-18: LOAD_AUTH — self-correcting stale session
 
-**Preconditions:** UC-17 occurred (session cleared). Credentials are correct.
+**Preconditions:** Data page returned LOAD_AUTH because the reused
+session was stale. Credentials are correct.
 
 | Step | Action | State change | Observable |
 |------|--------|-------------|------------|
 | 1 | Consumer calls `get_modem_data()` | | |
-| 2 | Collector: no session → fresh login → success | | |
-| 3 | Collector: load → parse → OK | | |
-| 4 | Orchestrator: streak→0 | streak reset | |
-| 5 | Return `ModemSnapshot(ONLINE)` | | |
+| 2 | Collector returns `ModemResult(signal=LOAD_AUTH)` | | |
+| 3 | Orchestrator: clear session | session cleared | |
+| 4 | Orchestrator: retry collection once in same poll | | |
+| 5 | Collector: no session → fresh login → success | | |
+| 6 | Collector: load → parse → OK | | |
+| 7 | Orchestrator: streak→0 | streak reset | |
+| 8 | Return `ModemSnapshot(ONLINE)` | | |
 
 **Assertions:**
 
-- Fresh login resolves the stale session
+- Fresh login resolves the stale session within the same poll
+- `auth_failed` is not surfaced when the retry succeeds
 - Streak resets to 0
-- Single LOAD_AUTH → fresh login → success is the expected self-healing path
+- Single LOAD_AUTH → same-poll fresh login → success is the expected
+  self-healing path
 
 ---
 
@@ -451,15 +461,17 @@ has expired the session (firmware timeout or max-session limit).
 | 2 | Collector: session valid (uid cookie + key) → reuse | | |
 | 3 | Resource Loader: POST /HNAP1/ with stale session → HTTP 404 | | |
 | 4 | Collector: HNAP error + reused session → LOAD_AUTH | | |
-| 5 | Orchestrator: streak++, collector.clear_session() | session cleared | |
-| 6 | Return `ModemSnapshot(AUTH_FAILED)` | | |
+| 5 | Orchestrator: collector.clear_session() | session cleared | |
+| 6 | Orchestrator: retry collection once in same poll | | |
+| 7 | Collector: fresh login → HNAP load → parse → OK | | ONLINE |
 
 **Assertions:**
 
 - Signal is LOAD_AUTH (not LOAD_ERROR) — session context determines routing
-- Session is cleared so next poll starts with fresh login (→ UC-18)
-- Auth failure streak is incremented
+- Session is cleared before the same-poll retry (→ UC-18)
+- Successful retry does not increment auth failure streak
 - WARNING log: "HNAP HTTP 404 on reused session [MODEL] — session likely expired"
+- INFO logs show the retry and successful same-poll recovery
 
 **Note:** Some HNAP firmware returns 404 for expired sessions, not 401.
 Others may return 500. The routing does not depend on the specific status
@@ -617,7 +629,7 @@ Modem has come back online.
 **Assertions:**
 
 - Transition is logged: "Status transition [MODEL]: unreachable → online"
-- If stale session rejected (3a): next poll does fresh login, self-corrects (UC-18)
+- If stale session rejected (3a): same poll does fresh login, self-corrects (UC-18)
 - No proactive session clear — LOAD_AUTH handles it naturally
 
 ---
@@ -1753,8 +1765,9 @@ password work on the next attempt. Retrying with known-bad credentials:
 
 **Distinguishing AUTH_FAILED from LOAD_AUTH:** LOAD_AUTH (401/403 on a
 data page after successful login) is a session issue, not a credential
-issue. LOAD_AUTH clears the session and the next poll re-authenticates
-fresh — this is self-correcting (UC-18). AUTH_FAILED is the modem
+issue. LOAD_AUTH clears the session and retries once in the same poll;
+if that fresh login succeeds, the condition self-corrects (UC-18).
+AUTH_FAILED is the modem
 rejecting the login itself.
 
 > **Status:** UC-20 documents the current behavior (threshold=6).

--- a/packages/cable_modem_monitor_core/solentlabs/cable_modem_monitor_core/orchestration/orchestrator.py
+++ b/packages/cable_modem_monitor_core/solentlabs/cable_modem_monitor_core/orchestration/orchestrator.py
@@ -315,6 +315,10 @@ class Orchestrator:
             result = self._collector.execute()
             collection_success = result.success
 
+            if not result.success and result.signal is CollectorSignal.LOAD_AUTH:
+                result = self._retry_load_auth_once()
+                collection_success = result.success
+
             if not result.success:
                 self._log_poll_result(result)
                 return self._handle_failure(result)
@@ -325,6 +329,29 @@ class Orchestrator:
         finally:
             if self._health_monitor is not None:
                 self._health_monitor.record_collection_end(collection_success)
+
+    def _retry_load_auth_once(self) -> ModemResult:
+        """Retry one LOAD_AUTH failure immediately with a fresh session.
+
+        LOAD_AUTH represents session expiry or stale auth state, not
+        credential rejection. Clear the current session and allow one
+        fresh collection attempt in the same poll to smooth over HNAP
+        session expiry without falling back to the next scheduled poll.
+        """
+        _logger.info(
+            "LOAD_AUTH [%s] — clearing session and retrying once in same poll",
+            self._modem_config.model,
+        )
+        self._collector.clear_session()
+
+        retry_result = self._collector.execute()
+        if retry_result.success:
+            _logger.info(
+                "LOAD_AUTH recovered [%s] — fresh login succeeded in same poll",
+                self._modem_config.model,
+            )
+
+        return retry_result
 
     def _handle_failure(self, result: ModemResult) -> ModemSnapshot:
         """Apply signal policy for a failed collection."""

--- a/packages/cable_modem_monitor_core/tests/orchestration/test_orchestrator.py
+++ b/packages/cable_modem_monitor_core/tests/orchestration/test_orchestrator.py
@@ -452,10 +452,7 @@ class TestStreakReset:
         )
         orch = _make_orchestrator(collector=collector)
 
-        orch.get_modem_data()  # LOAD_AUTH: streak → 1 (session issue, not credential rejection)
-        assert orch.diagnostics().auth_failure_streak == 1
-
-        orch.get_modem_data()  # success → streak → 0
+        orch.get_modem_data()  # LOAD_AUTH retried in same poll, success keeps streak at 0
         assert orch.diagnostics().auth_failure_streak == 0
         assert orch.diagnostics().circuit_breaker_open is False
 
@@ -527,7 +524,7 @@ class TestCircuitBreaker:
 
     def test_load_auth_uses_threshold(self) -> None:
         """LOAD_AUTH is a session issue — circuit trips at threshold, not immediately."""
-        results = [_fail_result(CollectorSignal.LOAD_AUTH) for _ in range(5)]
+        results = [_fail_result(CollectorSignal.LOAD_AUTH) for _ in range(10)]
         collector = _mock_collector(results)
         orch = _make_orchestrator(collector=collector)
 
@@ -566,7 +563,7 @@ class TestLoadAuth:
     """UC-17/18/19: LOAD_AUTH signal handling."""
 
     def test_load_auth_clears_session(self) -> None:
-        """UC-17: LOAD_AUTH clears session and increments streak."""
+        """UC-17: LOAD_AUTH clears session and increments streak on retry failure."""
         collector = _mock_collector(_fail_result(CollectorSignal.LOAD_AUTH))
         orch = _make_orchestrator(collector=collector)
 
@@ -574,10 +571,11 @@ class TestLoadAuth:
 
         assert snapshot.connection_status == ConnectionStatus.AUTH_FAILED
         assert orch.diagnostics().auth_failure_streak == 1
-        collector.clear_session.assert_called_once()
+        assert collector.execute.call_count == 2
+        collector.clear_session.assert_called()
 
-    def test_load_auth_self_corrects(self) -> None:
-        """UC-18: LOAD_AUTH → fresh login → success."""
+    def test_load_auth_recovers_in_same_poll(self) -> None:
+        """UC-18: LOAD_AUTH retries once immediately and returns success."""
         collector = _mock_collector(
             [
                 _fail_result(CollectorSignal.LOAD_AUTH),
@@ -586,15 +584,33 @@ class TestLoadAuth:
         )
         orch = _make_orchestrator(collector=collector)
 
-        orch.get_modem_data()  # LOAD_AUTH, session cleared
-        snapshot = orch.get_modem_data()  # fresh login → success
+        snapshot = orch.get_modem_data()
+
+        assert snapshot.connection_status == ConnectionStatus.ONLINE
+        assert orch.diagnostics().auth_failure_streak == 0
+        assert collector.execute.call_count == 2
+        collector.clear_session.assert_called_once()
+
+    def test_load_auth_self_corrects(self) -> None:
+        """UC-18: a later successful poll leaves the streak clear."""
+        collector = _mock_collector(
+            [
+                _fail_result(CollectorSignal.LOAD_AUTH),
+                _ok_result(),
+                _ok_result(),
+            ]
+        )
+        orch = _make_orchestrator(collector=collector)
+
+        orch.get_modem_data()  # LOAD_AUTH retried in same poll → success
+        snapshot = orch.get_modem_data()  # steady-state success
 
         assert snapshot.connection_status == ConnectionStatus.ONLINE
         assert orch.diagnostics().auth_failure_streak == 0
 
     def test_load_auth_escalates_to_circuit(self) -> None:
         """Persistent LOAD_AUTH eventually trips circuit breaker."""
-        results = [_fail_result(CollectorSignal.LOAD_AUTH) for _ in range(6)]
+        results = [_fail_result(CollectorSignal.LOAD_AUTH) for _ in range(12)]
         collector = _mock_collector(results)
         orch = _make_orchestrator(collector=collector)
 
@@ -1004,7 +1020,7 @@ class TestUnplannedRestart:
     """UC-49: Modem restarted externally — recovery through normal polling."""
 
     def test_outage_and_recovery_sequence(self) -> None:
-        """ONLINE → UNREACHABLE (with backoff) → LOAD_AUTH → ONLINE."""
+        """ONLINE → UNREACHABLE (with backoff) → LOAD_AUTH retry → ONLINE."""
         collector = _mock_collector()
         orch = _make_orchestrator(collector=collector)
 
@@ -1018,19 +1034,16 @@ class TestUnplannedRestart:
         snap = orch.get_modem_data()
         assert snap.connection_status == ConnectionStatus.UNREACHABLE
 
-        # Poll 3: Backoff clears, modem back but stale session — LOAD_AUTH
-        collector.execute.return_value = _fail_result(CollectorSignal.LOAD_AUTH, "401 on data page")
+        # Poll 3: Backoff clears, modem back but stale session — retry succeeds same poll
+        collector.execute.side_effect = [
+            _fail_result(CollectorSignal.LOAD_AUTH, "401 on data page"),
+            _ok_result(),
+        ]
         snap = orch.get_modem_data()
-        assert snap.connection_status == ConnectionStatus.AUTH_FAILED
-        # Session should have been cleared by LOAD_AUTH policy
+        assert snap.connection_status == ConnectionStatus.ONLINE
         collector.clear_session.assert_called()
         # Connectivity cleared because modem responded
         assert orch.diagnostics().connectivity_streak == 0
-
-        # Poll 4: Fresh login succeeds — ONLINE
-        collector.execute.return_value = _ok_result()
-        snap = orch.get_modem_data()
-        assert snap.connection_status == ConnectionStatus.ONLINE
 
     def test_connectivity_never_trips_circuit_breaker(self) -> None:
         """CONNECTIVITY failures never trip the auth circuit breaker."""
@@ -1046,7 +1059,7 @@ class TestUnplannedRestart:
         assert not orch.diagnostics().circuit_breaker_open
 
     def test_stale_session_self_corrects(self, caplog: pytest.LogCaptureFixture) -> None:
-        """LOAD_AUTH clears session, next poll authenticates fresh."""
+        """LOAD_AUTH clears session and recovers within the same poll."""
         collector = _mock_collector()
         orch = _make_orchestrator(collector=collector)
 
@@ -1055,16 +1068,15 @@ class TestUnplannedRestart:
         orch.get_modem_data()
 
         # Stale session detected
-        collector.execute.return_value = _fail_result(CollectorSignal.LOAD_AUTH, "401 on data page")
+        collector.execute.side_effect = [
+            _fail_result(CollectorSignal.LOAD_AUTH, "401 on data page"),
+            _ok_result(),
+        ]
         with caplog.at_level(logging.INFO):
-            orch.get_modem_data()
+            snap = orch.get_modem_data()
 
         assert "LOAD_AUTH" in caplog.text
-        collector.clear_session.assert_called()
-
-        # Fresh login succeeds
-        collector.execute.return_value = _ok_result()
-        snap = orch.get_modem_data()
+        collector.clear_session.assert_called_once()
         assert snap.connection_status == ConnectionStatus.ONLINE
 
 


### PR DESCRIPTION
# Description

Note this is tested with current main branch which I believe is 3.14.0 beta 1 plus any improvments.

Retry LOAD_AUTH failures once after clearing the cached session so stale HNAP sessions recover without surfacing a transient auth_failed state.

On the affected modem, the auth timeout is shorter than the 10 minute poll interval, so reused sessions can expire between polls. This keeps those polls successful without requiring a manual refresh or a follow-up poll to authenticate fresh.

## Type of Change

<!-- Please check the relevant option(s) -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement
- [ ] CI/CD improvement
- [ ] Dependency update

## Related Issues

Related to #140 

Related to #

## Changes Made

Add 1 time try re-auth try if session is expired

## Testing

Full test suite 1556 tests passed
orchestration test updated and passed as well

### Test Configuration

- **Integration Version**: 3.14.0 beta 1 *(Actually it is against current main)
- **Home Assistant Version**: 2026.4.0
- **Modem Model** (if applicable): Arris S33

### Test Steps

1. Run orchestration tests with small updated orchestration 


### Test Results

- [X] All existing tests pass
- [X] New tests added (if applicable)
- [X] Manual testing completed
- [ ] Pre-commit hooks pass

## Screenshots (if applicable)

<img width="504" height="315" alt="image" src="https://github.com/user-attachments/assets/af73c8c1-bf5a-455d-bb60-fe8e12694c8c" />

## Checklist

<!-- Please check all items that apply -->

### Code Quality

- [X] My code follows the project's style guidelines
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings or errors
- [X] I have run the linter (`make lint` or `ruff check`)
- [X] I have run the code formatter (`make format` or `black .`)

### Testing

- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes (`make test` or `pytest`)
- [X] I have tested this integration with a real modem (if applicable)

### Documentation

- [ ] I have updated the documentation accordingly (README, CHANGELOG, etc.)
- [ ] I have updated the CHANGELOG.md following [Keep a Changelog](https://keepachangelog.com/) format
- [ ] I have added docstrings to new functions/classes
- [ ] I have updated type hints (if applicable)

### For New Modem Support

<!-- Only applicable if adding support for a new modem model.
     The recommended path is the catalog_tools intake pipeline
     (/modem-intake skill), which generates configs from a HAR capture.
     See CONTRIBUTING.md § AI-Assisted Catalog Contribution. -->

- [ ] HAR captured with [`har-capture`](https://github.com/solentlabs/har-capture) (auto-sanitizes PII)
- [ ] Modem directory created: `packages/cable_modem_monitor_catalog/.../modems/<manufacturer>/<model>/`
- [ ] Contains: `modem.yaml`, `parser.yaml`, `test_data/modem.har`, `test_data/modem.expected.json`
- [ ] Catalog test suite discovers and passes for the new modem (`pytest packages/cable_modem_monitor_catalog/tests/`)
- [ ] Tested with actual modem hardware

### Compliance

- [ ] My changes respect user privacy and security
- [ ] I have read and agree to follow the [Code of Conduct](../CODE_OF_CONDUCT.md)
- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] My commit messages follow the project's commit message guidelines

## Breaking Changes

<!-- If this PR introduces breaking changes, describe them here and provide migration instructions -->

None / N/A

## Additional Notes

<!-- Any additional information that reviewers should know -->

## For Maintainers

<!-- Maintainers only - do not fill out -->

- [ ] Version bump required?
- [ ] Release notes drafted?
- [ ] Ready to merge?
